### PR TITLE
Lh/better count updates

### DIFF
--- a/Keas.Mvc/ClientApp/components/Access/AccessContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Access/AccessContainer.tsx
@@ -17,8 +17,8 @@ interface IState {
 }
 
 interface IProps {
-    accessAssigned?: (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => void;
-    accessRevoked?: (type: string, spaceId: number, personId: number) => void;
+    accessInUseUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
+    accessTotalUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
     accessEdited?: (type: string, spaceId: number, personId: number) => void; 
     person?: IPerson;
     spaceId?: number;
@@ -156,9 +156,13 @@ export default class AccessContainer extends React.Component<IProps, IState> {
             access: [...this.state.access, access]
         });
     }
-    if(this.props.accessAssigned)
+    if(created)
     {
-        this.props.accessAssigned("access", this.props.spaceId, this.props.person ? this.props.person.id : null, created, assigned);
+        this.props.accessTotalUpdated("access", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
+    }
+    if(assigned)
+    {
+        this.props.accessInUseUpdated("access", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
     }
   };
 
@@ -183,12 +187,9 @@ export default class AccessContainer extends React.Component<IProps, IState> {
               // if we are looking at a person, remove access entirely
               shallowCopy.splice(accessIndex, 1);
           }
-          this.setState({ access: shallowCopy });
+        this.setState({ access: shallowCopy });
 
-          if(this.props.accessRevoked)
-          {
-            this.props.accessRevoked("access", this.props.spaceId, this.props.person ? this.props.person.id : null);
-          }
+        this.props.accessInUseUpdated("access", this.props.spaceId, this.props.person ? this.props.person.id : null, -1);
       }
   }
 

--- a/Keas.Mvc/ClientApp/components/Equipment/AssignEquipment.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/AssignEquipment.tsx
@@ -12,7 +12,7 @@ import {
 
 import * as moment from "moment";
 import DatePicker from "react-datepicker";
-import { AppContext, IEquipment, IEquipmentAssignment, IEquipmentAttribute, IPerson } from "../../Types";
+import { AppContext, IEquipment, IEquipmentAssignment, IEquipmentAttribute, IPerson, ISpace } from "../../Types";
 import AssignPerson from "../Biographical/AssignPerson";
 import EquipmentEditValues from "./EquipmentEditValues";
 import SearchEquipment from "./SearchEquipment";
@@ -26,6 +26,7 @@ interface IProps {
   closeModal: () => void;
   selectedEquipment: IEquipment;
   person?: IPerson;
+  space: ISpace;
   tags: string[];
   commonAttributeKeys: string[];
 }
@@ -91,6 +92,7 @@ export default class AssignEquipment extends React.Component<IProps, IState> {
                     selectedEquipment={this.state.equipment}
                     onSelect={this._onSelected}
                     onDeselect={this._onDeselected}
+                    space={this.props.space}
                   />
                 </div>
                 {!this.state.equipment ||
@@ -102,6 +104,7 @@ export default class AssignEquipment extends React.Component<IProps, IState> {
                       disableEditing={false}
                       updateAttributes={this._updateAttributes}
                       creating={true}
+                      space={this.props.space}
                       tags={this.props.tags}
                     />
                   ))}

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
@@ -220,11 +220,6 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
         this.props.equipmentTotalUpdated("equipment", equipment.space ? equipment.space.id : null, 
           this.props.person ? this.props.person.id : null, 1);
     }
-    if(assigned)
-    {
-      this.props.equipmentInUseUpdated("equipment", equipment.space ? equipment.space.id : null, 
-      this.props.person ? this.props.person.id : null, 1);
-    }
   };
 
   private _revokeEquipment = async (equipment: IEquipment) => {

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
@@ -258,6 +258,17 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
       method: "POST"
     });
 
+    // if the space has been edited
+    if(!!this.props.spaceId && equipment.space.id !== this.state.equipment[index].space.id)
+    {
+        // remove one from total of old space
+        this.props.equipmentTotalUpdated("equipment", this.state.equipment[index].space.id,
+            this.props.person ? this.props.person.id : null, -1);
+        // and add one to total of new space
+        this.props.equipmentTotalUpdated("equipment", equipment.space.id,
+            this.props.person ? this.props.person.id : null, 1);
+  }
+
     updated.assignment = equipment.assignment;
 
     // update already existing entry in key
@@ -273,7 +284,7 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
     {
         this.props.equipmentEdited("equipment", this.props.spaceId, this.props.person ? this.props.person.id : null);
     }
-  }
+}
 
   private _filterTags = (filters: string[]) => {
     this.setState({tagFilters: filters});

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
@@ -22,8 +22,8 @@ interface IState {
 }
 
 interface IProps {
-  equipmentAssigned?: (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => void;
-  equipmentRevoked?: (type: string, spaceId: number, personId: number) => void;
+  equipmentInUseUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
+  equipmentTotalUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
   equipmentEdited?: (type: string, spaceId: number, personId: number) => void; 
   person?: IPerson;
   spaceId?: number;
@@ -211,9 +211,13 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
       });
     }
 
-    if(this.props.equipmentAssigned)
+    if(created)
     {
-        this.props.equipmentAssigned("equipment", this.props.spaceId, this.props.person ? this.props.person.id : null, created, assigned);
+        this.props.equipmentTotalUpdated("equipment", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
+    }
+    if(assigned)
+    {
+      this.props.equipmentInUseUpdated("equipment", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
     }
   };
 
@@ -236,10 +240,7 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
         shallowCopy.splice(index, 1);
       }
       this.setState({ equipment: shallowCopy });
-      if(this.props.equipmentRevoked)
-      {
-          this.props.equipmentRevoked("equipment", this.props.spaceId, this.props.person ? this.props.person.id : null);
-      }
+      this.props.equipmentInUseUpdated("equipment", this.props.spaceId, this.props.person ? this.props.person.id : null, -1);
     }
   };
 

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
@@ -207,7 +207,7 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
         equipment: updateEquipment
       });
     } else if (!!this.props.space && this.props.space.id !== equipment.space.id) {
-        // if we are on the space tab and we have assigned/created a space that is not in this space, do nothing to our state here
+        // if we are on the space tab and we have assigned/created an equipment that is not in this space, do nothing to our state here
     } else {
       this.setState({
         equipment: [...this.state.equipment, equipment]

--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentEditValues.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentEditValues.tsx
@@ -11,6 +11,7 @@ interface IProps {
     creating?: boolean;
     disableEditing: boolean;
     selectedEquipment: IEquipment;
+    space?: ISpace;
     tags?: string[];
     updateAttributes?: (attribute: IEquipmentAttribute[]) => void;
 }
@@ -95,6 +96,7 @@ export default class EquipmentEditValues extends React.Component<IProps, {}> {
                 </div>
 
                 {this.props.disableEditing &&
+                    // if we are looking at details, or if we are assigning
                     <div className="form-group">
                         <label>Room</label>
                         <input type="text"
@@ -106,13 +108,13 @@ export default class EquipmentEditValues extends React.Component<IProps, {}> {
                     </div>
                 }
                 {!this.props.disableEditing &&
+                    // if we are editing or creating 
                     <div className="form-group">
                         <label>Room</label>
-
-                    <AssignSpace onSelect={this._selectSpace} defaultSpace={this.props.selectedEquipment.space} />
+                    <AssignSpace
+                        onSelect={this._selectSpace} 
+                        defaultSpace={this.props.space ? this.props.space : this.props.selectedEquipment.space} />
                     </div>}
-              
-
             </div>
         );
     }

--- a/Keas.Mvc/ClientApp/components/Equipment/SearchEquipment.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/SearchEquipment.tsx
@@ -2,12 +2,13 @@
 import * as React from "react";
 import { AsyncTypeahead, Highlighter } from "react-bootstrap-typeahead";
 
-import { AppContext, IEquipment } from "../../Types";
+import { AppContext, IEquipment, ISpace } from "../../Types";
 
 interface IProps {
     selectedEquipment?: IEquipment;
     onSelect: (equipment: IEquipment) => void;
     onDeselect: () => void;
+    space: ISpace // used to set default space if we are on spaces tab
 }
 
 interface IState {
@@ -108,7 +109,7 @@ export default class SearchEquipment extends React.Component<IProps, IState> {
                 model: equipment.model ? equipment.model : "",
                 name: equipment.name,
                 serialNumber: equipment.serialNumber ? equipment.serialNumber : "",
-                space: equipment.space ? equipment.space : null,
+                space: this.props.space ? this.props.space : equipment.space, // if we are on spaces tab, auto to the right space
                 tags: "",
                 teamId: equipment.teamId ? equipment.teamId : 0,
                 type: "Phone"

--- a/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
@@ -152,11 +152,13 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     }
     if(created)
     {
-        this.props.keyTotalUpdated("key", this.props.space.id, this.props.person ? this.props.person.id : null, 1);
+        this.props.keyTotalUpdated("key", this.props.space ? this.props.space.id : null,
+           this.props.person ? this.props.person.id : null, 1);
     }
     if(assigned)
     {
-        this.props.keyInUseUpdated("key", this.props.space.id, this.props.person ? this.props.person.id : null, 1);
+        this.props.keyInUseUpdated("key", this.props.space ? this.props.space.id : null,
+          this.props.person ? this.props.person.id : null, 1);
     }
   };
 
@@ -179,7 +181,8 @@ export default class KeyContainer extends React.Component<IProps, IState> {
         shallowCopy.splice(index, 1);
       }
       this.setState({ keys: shallowCopy });
-      this.props.keyInUseUpdated("key", this.props.space.id, this.props.person ? this.props.person.id : null, -1);   
+      this.props.keyInUseUpdated("key", this.props.space ? this.props.space.id: null,
+        this.props.person ? this.props.person.id : null, -1);   
     }
   };
 
@@ -208,7 +211,8 @@ export default class KeyContainer extends React.Component<IProps, IState> {
 
     if(this.props.keyEdited)
     {
-      this.props.keyEdited("key", this.props.space.id, this.props.person ? this.props.person.id : null);
+      this.props.keyEdited("key", this.props.space ? this.props.space.id : null,
+        this.props.person ? this.props.person.id : null);
     }
     
     // TODO: handle count changes once keys are related to spaces
@@ -244,7 +248,7 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     if(!!this.props.person)
     {
       return `/${this.context.team.name}/people/details/${this.props.person.id}`;
-    } else if(!!this.props.space.id)
+    } else if(!!this.props.space)
     {
       return `/${this.context.team.name}/spaces/details/${this.props.space.id}`;
     } else {

--- a/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
@@ -210,6 +210,8 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     {
       this.props.keyEdited("key", this.props.spaceId, this.props.person ? this.props.person.id : null);
     }
+    
+    // TODO: handle count changes once keys are related to spaces
   }
 
   private _openAssignModal = (key: IKey) => {

--- a/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import * as React from "react";
 
-import { AppContext, IKey, IPerson } from "../../Types";
+import { AppContext, IKey, IPerson, ISpace } from "../../Types";
 
 import AssignKey from "./AssignKey";
 import EditKey from "./EditKey";
@@ -20,7 +20,7 @@ interface IProps {
   keyTotalUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
   keyEdited?: (type: string, spaceId: number, personId: number) => void; 
   person?: IPerson;
-  spaceId?: number;
+  space?: ISpace;
 }
 
 export default class KeyContainer extends React.Component<IProps, IState> {
@@ -45,8 +45,8 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     if(!!this.props.person)
     {
       keyFetchUrl = `/api/${this.context.team.name}/keys/listassigned?personid=${this.props.person.id}`;
-    } else if(!!this.props.spaceId) {
-      keyFetchUrl = `/api/${this.context.team.name}/keys/getKeysInSpace?spaceId=${this.props.spaceId}`;
+    } else if(!!this.props.space) {
+      keyFetchUrl = `/api/${this.context.team.name}/keys/getKeysInSpace?spaceId=${this.props.space.id}`;
     } else {
       keyFetchUrl = `/api/${this.context.team.name}/keys/list/`;
     }
@@ -152,11 +152,11 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     }
     if(created)
     {
-        this.props.keyTotalUpdated("key", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
+        this.props.keyTotalUpdated("key", this.props.space.id, this.props.person ? this.props.person.id : null, 1);
     }
     if(assigned)
     {
-        this.props.keyInUseUpdated("key", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
+        this.props.keyInUseUpdated("key", this.props.space.id, this.props.person ? this.props.person.id : null, 1);
     }
   };
 
@@ -179,7 +179,7 @@ export default class KeyContainer extends React.Component<IProps, IState> {
         shallowCopy.splice(index, 1);
       }
       this.setState({ keys: shallowCopy });
-      this.props.keyInUseUpdated("key", this.props.spaceId, this.props.person ? this.props.person.id : null, -1);   
+      this.props.keyInUseUpdated("key", this.props.space.id, this.props.person ? this.props.person.id : null, -1);   
     }
   };
 
@@ -208,7 +208,7 @@ export default class KeyContainer extends React.Component<IProps, IState> {
 
     if(this.props.keyEdited)
     {
-      this.props.keyEdited("key", this.props.spaceId, this.props.person ? this.props.person.id : null);
+      this.props.keyEdited("key", this.props.space.id, this.props.person ? this.props.person.id : null);
     }
     
     // TODO: handle count changes once keys are related to spaces
@@ -244,9 +244,9 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     if(!!this.props.person)
     {
       return `/${this.context.team.name}/people/details/${this.props.person.id}`;
-    } else if(!!this.props.spaceId)
+    } else if(!!this.props.space.id)
     {
-      return `/${this.context.team.name}/spaces/details/${this.props.spaceId}`;
+      return `/${this.context.team.name}/spaces/details/${this.props.space.id}`;
     } else {
       return `/${this.context.team.name}`;
     }

--- a/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
@@ -250,4 +250,5 @@ export default class KeyContainer extends React.Component<IProps, IState> {
     } else {
       return `/${this.context.team.name}`;
     }
+  }
 }

--- a/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Keys/KeyContainer.tsx
@@ -16,8 +16,8 @@ interface IState {
 }
 
 interface IProps {
-  keyAssigned?: (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => void;
-  keyRevoked?: (type: string, spaceId: number, personId: number) => void;
+  keyInUseUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
+  keyTotalUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
   keyEdited?: (type: string, spaceId: number, personId: number) => void; 
   person?: IPerson;
   spaceId?: number;
@@ -150,9 +150,13 @@ export default class KeyContainer extends React.Component<IProps, IState> {
         keys: [...this.state.keys, key]
       });
     }
-    if(this.props.keyAssigned)
+    if(created)
     {
-        this.props.keyAssigned("key", this.props.spaceId, this.props.person ? this.props.person.id : null, created, assigned);
+        this.props.keyTotalUpdated("key", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
+    }
+    if(assigned)
+    {
+        this.props.keyInUseUpdated("key", this.props.spaceId, this.props.person ? this.props.person.id : null, 1);
     }
   };
 
@@ -175,11 +179,7 @@ export default class KeyContainer extends React.Component<IProps, IState> {
         shallowCopy.splice(index, 1);
       }
       this.setState({ keys: shallowCopy });
-
-      if(this.props.keyRevoked)
-      {
-        this.props.keyRevoked("key", this.props.spaceId, this.props.person ? this.props.person.id : null);
-      }    
+      this.props.keyInUseUpdated("key", this.props.spaceId, this.props.person ? this.props.person.id : null, -1);   
     }
   };
 

--- a/Keas.Mvc/ClientApp/components/People/PeopleContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/People/PeopleContainer.tsx
@@ -132,6 +132,8 @@ export default class PeopleContainer extends React.Component<{}, IState> {
 }
 
 private _assetTotalUpdated = (type: string, spaceId: number, personId: number, count: number) => {
+  // this will be used when we have different key counts
+
   // const index = this.state.people.findIndex(x => x.id === personId);
   // if(index > -1)
   // {

--- a/Keas.Mvc/ClientApp/components/People/PeopleContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/People/PeopleContainer.tsx
@@ -132,7 +132,7 @@ export default class PeopleContainer extends React.Component<{}, IState> {
 }
 
 private _assetTotalUpdated = (type: string, spaceId: number, personId: number, count: number) => {
-  // this will be used when we have different key counts
+  // TODO: this will be used when we have different key counts
 
   // const index = this.state.people.findIndex(x => x.id === personId);
   // if(index > -1)

--- a/Keas.Mvc/ClientApp/components/People/PeopleContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/People/PeopleContainer.tsx
@@ -98,8 +98,8 @@ export default class PeopleContainer extends React.Component<{}, IState> {
         selectedPerson={detailPerson}
         tags={this.state.tags}
         goBack={this._goBack}
-        assignedOrCreated={this._assetAssigned}
-        revokedOrDeleted={this._assetRevoked}
+        inUseUpdated={this._assetInUseUpdated}
+        totalUpdated={this._assetTotalUpdated}
       />
     );
   }
@@ -108,49 +108,49 @@ export default class PeopleContainer extends React.Component<{}, IState> {
     this.setState({tableFilters: filters});
   }
 
-  // managing counts
-  private _assetAssigned = (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => {
+  // managing counts for assigned or revoked
+  private _assetInUseUpdated = (type: string, spaceId: number, personId: number, count: number) => {
     const index = this.state.people.findIndex(x => x.id === personId);
     if(index > -1)
     {
         const people = [...this.state.people];
         switch(type) {
           case "equipment": 
-            people[index].equipmentCount++;
+            people[index].equipmentCount += count;
             break;
           case "key":
-            people[index].keyCount++;
+            people[index].keyCount += count;
             break;
           case "access":
-            people[index].accessCount++;
+            people[index].accessCount += count;
             break;
           case "workstation":
-            people[index].workstationCount++
+            people[index].workstationCount += count;
         }
         this.setState({people});
     } 
 }
 
-private _assetRevoked = (type: string, spaceId: number, personId: number) => {
-  const index = this.state.people.findIndex(x => x.id === personId);
-  if(index > -1)
-  {
-      const people = [...this.state.people];
-      switch(type) {
-        case "equipment": 
-          people[index].equipmentCount--;
-          break;
-        case "key":
-          people[index].keyCount--;
-          break;
-        case "access":
-          people[index].accessCount--;
-          break;
-        case "workstation":
-          people[index].workstationCount--;
-      }
-      this.setState({people});
-  } 
+private _assetTotalUpdated = (type: string, spaceId: number, personId: number, count: number) => {
+  // const index = this.state.people.findIndex(x => x.id === personId);
+  // if(index > -1)
+  // {
+  //     const people = [...this.state.people];
+  //     switch(type) {
+  //       case "equipment": 
+  //         people[index].equipmentCount += count;
+  //         break;
+  //       case "key":
+  //         people[index].keyCount += count;
+  //         break;
+  //       case "access":
+  //         people[index].accessCount += count;
+  //         break;
+  //       case "workstation":
+  //         people[index].workstationCount += count;
+  //     }
+  //     this.setState({people});
+  // } 
 }
 
   // tags 

--- a/Keas.Mvc/ClientApp/components/People/PersonDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/People/PersonDetails.tsx
@@ -19,8 +19,8 @@ interface IProps {
     goBack: () => void;
     selectedPerson: IPerson;
     tags: string[];
-    assignedOrCreated: (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => void;
-    revokedOrDeleted: (type: string, spaceId: number, personId: number) => void;
+    inUseUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
+    totalUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
     edited?: (type: string, spaceId: number, personId: number) => void;
 }
 
@@ -44,23 +44,23 @@ export default class PersonDetails extends React.Component<IProps, {}> {
                 <div>
                         <BioContainer person={this.props.selectedPerson} />
                         <KeyContainer person={this.props.selectedPerson}
-                            keyAssigned={this.props.assignedOrCreated}
-                            keyRevoked={this.props.revokedOrDeleted}
+                            keyInUseUpdated={this.props.inUseUpdated}
+                            keyTotalUpdated={this.props.totalUpdated}
                             keyEdited={this.props.edited}
                         />
                         <EquipmentContainer person={this.props.selectedPerson}
-                            equipmentAssigned={this.props.assignedOrCreated}
-                            equipmentRevoked={this.props.revokedOrDeleted}
+                            equipmentInUseUpdated={this.props.inUseUpdated}
+                            equipmentTotalUpdated={this.props.totalUpdated}
                             equipmentEdited={this.props.edited}/>
                         <AccessContainer person={this.props.selectedPerson} 
-                            accessAssigned={this.props.assignedOrCreated}
-                            accessRevoked={this.props.revokedOrDeleted}
+                            accessInUseUpdated={this.props.inUseUpdated}
+                            accessTotalUpdated={this.props.totalUpdated}
                             accessEdited={this.props.edited}/>
                         <WorkstationContainer 
                             person={this.props.selectedPerson} 
                             tags={this.props.tags}
-                            workstationAssigned={this.props.assignedOrCreated}
-                            workstationRevoked={this.props.revokedOrDeleted}
+                            workstationInUseUpdated={this.props.inUseUpdated}
+                            workstationTotalUpdated={this.props.totalUpdated}
                             workstationEdited={this.props.edited}/>
                         <HistoryContainer controller="people" id={this.props.selectedPerson.id} />
                 </div>

--- a/Keas.Mvc/ClientApp/components/Spaces/AssignSpace.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/AssignSpace.tsx
@@ -43,7 +43,8 @@ export default class AssignSpace extends React.Component<IProps, IState> {
                         this.props.defaultSpace.roomNumber + " " + this.props.defaultSpace.bldgName : ""}
                     labelKey={(option: ISpace) =>
                         `${option.roomNumber} ${option.bldgName}`
-                    }                    filterBy={() => true} 
+                    }
+                    filterBy={() => true} 
                     renderMenuItemChildren={(option, props, index) => (
                         <div>
                             <div>

--- a/Keas.Mvc/ClientApp/components/Spaces/SpaceDetailContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpaceDetailContainer.tsx
@@ -12,7 +12,7 @@ export default class SpacesDetailContainer extends React.Component<IProps, {}> {
     return (
       <div className="card">
         <div className="card-body">
-          <h4 className="card-title">{this.props.space.bldgName} {this.props.space.roomNumber}</h4>
+          <h4 className="card-title">{this.props.space.roomNumber} {this.props.space.bldgName}</h4>
           <div className="card-text">
             {this.props.space.roomName && <div>{this.props.space.roomName}</div>}
           </div>

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesContainer.tsx
@@ -146,22 +146,23 @@ export default class SpacesContainer extends React.Component<{}, IState> {
     }
 
     private _assetTotalUpdated = (type: string, spaceId: number, personId: number, count: number) => {
-    const index = this.state.spaces.findIndex(x => x.id === spaceId);
-    if(index > -1)
-    {
-        const spaces = [...this.state.spaces];
-        switch(type) {
-            case "equipment": 
-            spaces[index].equipmentCount += count;
-            break;
-            case "key":
-            spaces[index].keyCount += count;
-            break;
-            case "workstation":
-            spaces[index].workstationsTotal += count;
-        }
-        this.setState({spaces});
-    } 
+        // this is called when we are either changing the room on an asset, or creating a workstation
+        const index = this.state.spaces.findIndex(x => x.id === spaceId);
+        if(index > -1)
+        {
+            const spaces = [...this.state.spaces];
+            switch(type) {
+                case "equipment": 
+                spaces[index].equipmentCount += count;
+                break;
+                case "key":
+                spaces[index].keyCount += count;
+                break;
+                case "workstation":
+                spaces[index].workstationsTotal += count;
+            }
+            this.setState({spaces});
+        } 
     }
 
     private _assetEdited = async (type: string, spaceId: number, personId: number) => {

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesContainer.tsx
@@ -127,6 +127,7 @@ export default class SpacesContainer extends React.Component<{}, IState> {
 
     // managing counts for assigned or revoked
     private _assetInUseUpdated = (type: string, spaceId: number, personId: number, count: number) => {
+        // this is called when we are assigning or revoking an asset
         const index = this.state.spaces.findIndex(x => x.id === spaceId);
         if(index > -1)
         {

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesContainer.tsx
@@ -104,8 +104,8 @@ export default class SpacesContainer extends React.Component<{}, IState> {
                     closeModal={this._closeModals}
                     selectedSpace={selectedSpace}
                     tags={this.state.tags}
-                    assignedOrCreated={this._assetAssignedOrCreated}
-                    revokedOrDeleted={this._assetRevokedOrDeleted}
+                    inUseUpdated={this._assetInUseUpdated}
+                    totalUpdated={this._assetTotalUpdated}
                     edited={this._assetEdited}
                     />
         );
@@ -125,47 +125,40 @@ export default class SpacesContainer extends React.Component<{}, IState> {
         this.context.router.history.push(`${this._getBaseUrl()}/spaces`);
     };
 
-      // managing counts
-    private _assetAssignedOrCreated = (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => {
+    // managing counts for assigned or revoked
+    private _assetInUseUpdated = (type: string, spaceId: number, personId: number, count: number) => {
         const index = this.state.spaces.findIndex(x => x.id === spaceId);
         if(index > -1)
         {
             const spaces = [...this.state.spaces];
             switch(type) {
             case "equipment": 
-                spaces[index].equipmentCount++;
+                spaces[index].equipmentCount += count;
                 break;
             case "key":
-                spaces[index].keyCount++;
+                spaces[index].keyCount += count;
                 break;
             case "workstation":
-                if(created) {
-                    spaces[index].workstationsTotal++;
-                }
-                if(assigned)
-                {
-                    spaces[index].workstationsInUse++;
-                }
+                spaces[index].workstationsInUse += count;
             }
             this.setState({spaces});
         } 
     }
 
-    private _assetRevokedOrDeleted = (type: string, spaceId: number, personId: number) => {
+    private _assetTotalUpdated = (type: string, spaceId: number, personId: number, count: number) => {
     const index = this.state.spaces.findIndex(x => x.id === spaceId);
     if(index > -1)
     {
-        // TODO: add flag for deleting and also edit workstationsTotal
         const spaces = [...this.state.spaces];
         switch(type) {
             case "equipment": 
-            spaces[index].equipmentCount--;
+            spaces[index].equipmentCount += count;
             break;
             case "key":
-            spaces[index].keyCount--;
+            spaces[index].keyCount += count;
             break;
             case "workstation":
-            spaces[index].workstationsInUse--;
+            spaces[index].workstationsTotal += count;
         }
         this.setState({spaces});
     } 

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
@@ -44,12 +44,12 @@ export default class SpacesDetails extends React.Component<IProps, {}> {
                 <div>
                     {this.props.selectedSpace.roomName &&
                     <SpaceDetailContainer space={this.props.selectedSpace}/>}
-                    <KeyContainer spaceId={this.props.selectedSpace.id}
+                    <KeyContainer space={this.props.selectedSpace}
                             keyInUseUpdated={this.props.inUseUpdated}
                             keyTotalUpdated={this.props.totalUpdated}
                             keyEdited={this.props.edited}
                         />
-                    <EquipmentContainer spaceId={this.props.selectedSpace.id}
+                    <EquipmentContainer space={this.props.selectedSpace}
                         equipmentInUseUpdated={this.props.inUseUpdated}
                         equipmentTotalUpdated={this.props.totalUpdated}
                         equipmentEdited={this.props.edited}/>

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
@@ -42,7 +42,7 @@ export default class SpacesDetails extends React.Component<IProps, {}> {
                 </div>
                 <hr />
                 <div>
-                    {this.props.selectedSpace.roomName &&
+                    {this.props.selectedSpace &&
                     <SpaceDetailContainer space={this.props.selectedSpace}/>}
                     <KeyContainer space={this.props.selectedSpace}
                             keyInUseUpdated={this.props.inUseUpdated}

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
@@ -19,8 +19,8 @@ import SpaceDetailContainer from "./SpaceDetailContainer";
 interface IProps {
     closeModal: () => void;
     selectedSpace: ISpace;
-    assignedOrCreated: (type: string, spaceId: number, personId: number, created: boolean, assigned: boolean) => void;
-    revokedOrDeleted: (type: string, spaceId: number, personId: number) => void;
+    inUseUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
+    totalUpdated: (type: string, spaceId: number, personId: number, count: number) => void;
     edited: (type: string, spaceId: number, personId: number) => void;
     tags: string[];
 }
@@ -45,20 +45,20 @@ export default class SpacesDetails extends React.Component<IProps, {}> {
                     {this.props.selectedSpace.roomName &&
                     <SpaceDetailContainer space={this.props.selectedSpace}/>}
                     <KeyContainer spaceId={this.props.selectedSpace.id}
-                        keyAssigned={this.props.assignedOrCreated}
-                        keyEdited={this.props.edited}
-                        keyRevoked={this.props.revokedOrDeleted} />
-                    <EquipmentContainer spaceId={this.props.selectedSpace.id} 
-                        equipmentAssigned={this.props.assignedOrCreated}
-                        equipmentEdited={this.props.edited}
-                        equipmentRevoked={this.props.revokedOrDeleted}/>
+                            keyInUseUpdated={this.props.inUseUpdated}
+                            keyTotalUpdated={this.props.totalUpdated}
+                            keyEdited={this.props.edited}
+                        />
+                    <EquipmentContainer spaceId={this.props.selectedSpace.id}
+                        equipmentInUseUpdated={this.props.inUseUpdated}
+                        equipmentTotalUpdated={this.props.totalUpdated}
+                        equipmentEdited={this.props.edited}/>
                     <WorkstationContainer 
                         spaceId={this.props.selectedSpace.id} 
                         tags={this.props.tags}
-                        workstationAssigned={this.props.assignedOrCreated}
-                        workstationEdited={this.props.edited}
-                        workstationRevoked={this.props.revokedOrDeleted}
-                    />
+                        workstationInUseUpdated={this.props.inUseUpdated}
+                        workstationTotalUpdated={this.props.totalUpdated}
+                        workstationEdited={this.props.edited}/>
                 </div>
                 <hr/>
                 <div>

--- a/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
+++ b/Keas.Mvc/ClientApp/components/Spaces/SpacesDetails.tsx
@@ -54,7 +54,7 @@ export default class SpacesDetails extends React.Component<IProps, {}> {
                         equipmentTotalUpdated={this.props.totalUpdated}
                         equipmentEdited={this.props.edited}/>
                     <WorkstationContainer 
-                        spaceId={this.props.selectedSpace.id} 
+                        space={this.props.selectedSpace} 
                         tags={this.props.tags}
                         workstationInUseUpdated={this.props.inUseUpdated}
                         workstationTotalUpdated={this.props.totalUpdated}

--- a/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
@@ -69,7 +69,7 @@ export default class AssignWorkstation extends React.Component<IProps, IState> {
     return (
       <div>
          <Modal isOpen={this.props.modal} 
-                toggle={this.props.closeModal} 
+                toggle={this._closeModal} 
                 size="lg">
                 <ModalHeader>Assign Workstation</ModalHeader>
           <ModalBody>
@@ -125,7 +125,7 @@ export default class AssignWorkstation extends React.Component<IProps, IState> {
                     <Button color="primary" onClick={this._assignSelected}>
                         Save
                     </Button>
-                    <Button color="secondary" onClick={this.props.closeModal}>
+                    <Button color="secondary" onClick={this._closeModal}>
                         Close
                     </Button>
                 </ModalFooter>

--- a/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
@@ -12,6 +12,7 @@ import {
 import { AppContext, IPerson, ISpace, IWorkstation } from "../../Types";
 import AssignPerson from "../Biographical/AssignPerson";
 import HistoryContainer from "../History/HistoryContainer";
+import SearchWorkstations from "./SearchWorkstations";
 import WorkstationEditValues from "./WorkstationEditValues";
 
 import "react-datepicker/dist/react-datepicker.css";
@@ -49,14 +50,7 @@ export default class AssignWorkstation extends React.Component<IProps, IState> {
         error: "",
         person: null,
         validState: false,
-        workstation: {
-            assignment: null,
-            id: 0,
-            name: "",
-            space: this.props.space,
-            tags:"",
-            teamId: 0
-        }    
+        workstation: this.props.selectedWorkstation
     };
 }
 
@@ -88,6 +82,15 @@ export default class AssignWorkstation extends React.Component<IProps, IState> {
                     onSelect={this._onSelectPerson}
                   />
                 </div>
+                <div className="form-group">
+                  <label>Pick a workstation to assign</label>
+                  <SearchWorkstations
+                    selectedWorkstation={this.state.workstation}
+                    onSelect={this._onSelected}
+                    onDeselect={this._onDeselected}
+                    space={this.props.space}
+                  />
+                  </div>
                 {(!this.state.workstation || !this.state.workstation.teamId) && // if we are creating a new workstation, edit properties
                     <WorkstationEditValues
                       tags={this.props.tags}

--- a/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
@@ -9,7 +9,7 @@ import {
     ModalFooter,
     ModalHeader,
 } from "reactstrap";
-import { AppContext, IPerson, IWorkstation } from "../../Types";
+import { AppContext, IPerson, ISpace, IWorkstation } from "../../Types";
 import AssignPerson from "../Biographical/AssignPerson";
 import HistoryContainer from "../History/HistoryContainer";
 import WorkstationEditValues from "./WorkstationEditValues";
@@ -23,6 +23,7 @@ interface IProps {
   closeModal: () => void;
   selectedWorkstation: IWorkstation;
   person?: IPerson;
+  space?: ISpace;
   tags: string[];
 }
 
@@ -52,7 +53,7 @@ export default class AssignWorkstation extends React.Component<IProps, IState> {
             assignment: null,
             id: 0,
             name: "",
-            space: null,
+            space: this.props.space,
             tags:"",
             teamId: 0
         }    

--- a/Keas.Mvc/ClientApp/components/Workstations/SearchWorkstations.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/SearchWorkstations.tsx
@@ -42,7 +42,8 @@ export default class SearchWorkstations extends React.Component<IProps, IState> 
     }
 
     private _renderSelectWorkstation = () => {
-
+        const searchUrl = this.props.space ? `/api/${this.context.team.name}/workstations/searchInSpace?spaceId=${this.props.space.id}&q=` :
+            `/api/${this.context.team.name}/workstations/search?q=`;
         return (
             <div>
                 <AsyncTypeahead
@@ -72,7 +73,7 @@ export default class SearchWorkstations extends React.Component<IProps, IState> 
                     onSearch={async query => {
                         this.setState({ isSearchLoading: true });
                         const workstations = await this.context.fetch(
-                            `/api/${this.context.team.name}/workstations/search?q=${query}&spaceId=${this.props.space ? this.props.space.id : null}`
+                            searchUrl + query
                         );
                         this.setState({
                             isSearchLoading: false,

--- a/Keas.Mvc/ClientApp/components/Workstations/SearchWorkstations.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/SearchWorkstations.tsx
@@ -1,0 +1,120 @@
+﻿import PropTypes from "prop-types";
+import * as React from "react";
+import { AsyncTypeahead, Highlighter } from "react-bootstrap-typeahead";
+
+import { AppContext, ISpace, IWorkstation } from "../../Types";
+
+interface IProps {
+    selectedWorkstation?: IWorkstation;
+    space: ISpace;
+    onSelect: (workstation: IWorkstation) => void;
+    onDeselect: () => void;
+}
+
+interface IState {
+    isSearchLoading: boolean;
+    workstations: IWorkstation[];
+}
+
+// Search for existing workstation then send selection back to parent
+export default class SearchWorkstations extends React.Component<IProps, IState> {
+    public static contextTypes = {
+        fetch: PropTypes.func,
+        person: PropTypes.object,
+        team: PropTypes.object
+    };
+    public context: AppContext;
+    constructor(props) {
+        super(props);
+        this.state = {
+            isSearchLoading: false,
+            workstations: [],
+        };
+    }
+
+    public render() {
+        if (this.props.selectedWorkstation != null) {
+            return this._renderExistingWorkstation();
+        }
+        else {
+            return this._renderSelectWorkstation();
+        }
+    }
+
+    private _renderSelectWorkstation = () => {
+
+        return (
+            <div>
+                <AsyncTypeahead
+                    isLoading={this.state.isSearchLoading}
+                    minLength={3}
+                    placeholder="Search for workstation by name or room"
+                    labelKey="name"
+                    filterBy={() => true} // don't filter on top of our search
+                    allowNew={true}
+                    renderMenuItemChildren={(option, props, index) => (
+                        <div>
+                            <div>
+                                <Highlighter key="name" search={props.text}>
+                                    {option.name}
+                                </Highlighter>
+                            </div>
+                            <div>
+                                <small>
+                                    Room: {" "}
+                                    <Highlighter key="space.roomNumber" search={props.text}>{option.space.roomNumber}</Highlighter>
+                                    {" "} 
+                                    <Highlighter key="space.bldgName" search={props.text}>{option.space.bldgName}</Highlighter>
+                                </small>
+                            </div>
+                        </div>
+                    )}
+                    onSearch={async query => {
+                        this.setState({ isSearchLoading: true });
+                        const workstations = await this.context.fetch(
+                            `/api/${this.context.team.name}/workstations/search?q=${query}&spaceId=${this.props.space ? this.props.space.id : null}`
+                        );
+                        this.setState({
+                            isSearchLoading: false,
+                            workstations
+                        });
+                    }}
+                    onChange={selected => {
+                        if (selected && selected.length === 1) {
+                            this._onSelected(selected[0]);
+                        }
+                    }}
+                    options={this.state.workstations}
+                />
+            </div>
+        );
+    }
+
+    private _renderExistingWorkstation = () => {
+        return (
+            <input
+                type="text"
+                className="form-control"
+                value={this.props.selectedWorkstation.name}
+                disabled={true}
+            />
+        );
+    };
+
+    private _onSelected = (workstation: IWorkstation) => {
+        // onChange is called when deselected
+        if (workstation == null || workstation.name == null) {
+            this.props.onDeselect();
+        }
+        else {
+            // if teamId is not set, this is a new workstation
+            this.props.onSelect({
+                id: workstation.teamId ? workstation.id : 0,
+                name: workstation.name,
+                space: workstation.teamId ? workstation.space : this.props.space,
+                tags: workstation.teamId ? workstation.tags : "",
+                teamId: workstation.teamId ? workstation.teamId : 0,
+            });
+        }
+    };
+}

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
@@ -205,7 +205,6 @@ export default class WorkstationContainer extends React.Component<IProps, IState
       private _editWorkstation = async (workstation: IWorkstation) =>
       {
         const index = this.state.workstations.findIndex(x => x.id === workstation.id);
-        debugger;
         if(index === -1 ) // should always already exist
         {
           return;
@@ -214,13 +213,9 @@ export default class WorkstationContainer extends React.Component<IProps, IState
           body: JSON.stringify(workstation),
           method: "POST"
         });
-        debugger;
         // if the space has been edited
         if(workstation.space.id !== this.state.workstations[index].space.id)
         {
-            debugger;
-            console.log(workstation.space.id);
-            console.log(this.state.workstations[index].space.id);
             // remove one from total of old space
             this.props.workstationTotalUpdated("workstation", this.state.workstations[index].space.id,
                 this.props.person ? this.props.person.id : null, -1);

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
@@ -213,12 +213,21 @@ export default class WorkstationContainer extends React.Component<IProps, IState
           body: JSON.stringify(workstation),
           method: "POST"
         });
-        // if the space has been edited
+
+        updated.assignment = workstation.assignment;
+
+        // update already existing entry in key
+        const updateWorkstation = [...this.state.workstations];
+        updateWorkstation[index] = updated;
+
+        // if on spaces tab and the space has been edited
         if(!!this.props.spaceId && workstation.space.id !== this.state.workstations[index].space.id)
         {
             // remove one from total of old space
             this.props.workstationTotalUpdated("workstation", this.state.workstations[index].space.id,
                 this.props.person ? this.props.person.id : null, -1);
+            // remove from this state
+            updateWorkstation.splice(index, 1);
             // and add one to total of new space
             this.props.workstationTotalUpdated("workstation", workstation.space.id,
                 this.props.person ? this.props.person.id : null, 1);
@@ -231,13 +240,8 @@ export default class WorkstationContainer extends React.Component<IProps, IState
                 this.props.workstationInUseUpdated("workstation", workstation.space.id,
                     this.props.person ? this.props.person.id : null, 1);
             }
-        }
-        updated.assignment = workstation.assignment;
-    
-        // update already existing entry in key
-        const updateWorkstation = [...this.state.workstations];
-        updateWorkstation[index] = updated;
-    
+        }    
+
         this.setState({
           ...this.state,
           workstations: updateWorkstation

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
@@ -59,7 +59,7 @@ export default class WorkstationContainer extends React.Component<IProps, IState
     }
 
     public render() {
-        if (!this.props.space)
+        if (!this.props.space && !this.props.person)
         {
             return null;
         }

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
@@ -48,7 +48,7 @@ export default class WorkstationContainer extends React.Component<IProps, IState
         if(!this.props.space && !!this.props.person)
         {
             workstations = 
-                await this.context.fetch(`/api/${this.context.team.name}/workstations/getWorkstationsAssigned?personId=${this.props.person.id}`);
+                await this.context.fetch(`/api/${this.context.team.name}/workstations/listAssigned?personId=${this.props.person.id}`);
         }
         if(!!this.props.space && !this.props.person)
         {

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
@@ -214,7 +214,7 @@ export default class WorkstationContainer extends React.Component<IProps, IState
           method: "POST"
         });
         // if the space has been edited
-        if(workstation.space.id !== this.state.workstations[index].space.id)
+        if(!!this.props.spaceId && workstation.space.id !== this.state.workstations[index].space.id)
         {
             // remove one from total of old space
             this.props.workstationTotalUpdated("workstation", this.state.workstations[index].space.id,

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationEditValues.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationEditValues.tsx
@@ -9,6 +9,7 @@ interface IProps {
     tags?: string[];
     disableEditing: boolean;
     selectedWorkstation: IWorkstation;
+    space?: ISpace;
     creating?: boolean;
 }
 
@@ -67,7 +68,8 @@ export default class WorkstationEditValues extends React.Component<IProps, {}> {
                     <div className="form-group">
                         <label>Room</label>
 
-                    <AssignSpace onSelect={(space) => this.props.changeProperty("space", space)} defaultSpace={this.props.selectedWorkstation.space} />
+                    <AssignSpace onSelect={(space) => this.props.changeProperty("space", space)} 
+                        defaultSpace={this.props.space ? this.props.space : this.props.selectedWorkstation.space} />
                     </div>}
               
                 <div className="form-group">

--- a/Keas.Mvc/Controllers/Api/EquipmentController.cs
+++ b/Keas.Mvc/Controllers/Api/EquipmentController.cs
@@ -42,6 +42,9 @@ namespace Keas.Mvc.Controllers.Api
         {
             var equipment = await _context.Equipment
                 .Where(x => x.Space.Id == spaceId && x.Team.Name == Team && x.Active)
+                .Include(x => x.Space)
+                .Include(x => x.Attributes)
+                .Include(x => x.Team)
                 .Include(x => x.Assignment)
                 .ThenInclude(x => x.Person.User)
                 .AsNoTracking()

--- a/Keas.Mvc/Controllers/Api/WorkstationsController.cs
+++ b/Keas.Mvc/Controllers/Api/WorkstationsController.cs
@@ -25,11 +25,14 @@ namespace Keas.Mvc.Controllers.Api
         public async Task<IActionResult> Search(string q)
         {
             var comparison = StringComparison.OrdinalIgnoreCase;
-            var workstation = await _context.Workstations
-                .Where(w => w.Team.Name == Team && w.Active && w.Assignment == null && w.Name.StartsWith(q, comparison))
+            var equipment = await _context.Workstations
+                .Where(x => x.Team.Name == Team && x.Active && x.Assignment == null &&
+                (x.Name.StartsWith(q,comparison) || x.Space.BldgName.IndexOf(q,comparison) >= 0 // case-insensitive .Contains
+                    || x.Space.RoomNumber.StartsWith(q, comparison)))
+                .Include(x => x.Space)
                 .AsNoTracking().ToListAsync();
 
-            return Json(workstation);
+            return Json(equipment);
         }
 
         public async Task<IActionResult> GetWorkstationsInSpace(int spaceId)

--- a/Keas.Mvc/Controllers/Api/WorkstationsController.cs
+++ b/Keas.Mvc/Controllers/Api/WorkstationsController.cs
@@ -35,6 +35,20 @@ namespace Keas.Mvc.Controllers.Api
             return Json(equipment);
         }
 
+        
+        public async Task<IActionResult> SearchInSpace(int spaceId, string q)
+        {
+            var comparison = StringComparison.OrdinalIgnoreCase;
+            var equipment = await _context.Workstations
+                .Where(x => x.Team.Name == Team && x.SpaceId == spaceId && x.Active && x.Assignment == null &&
+                (x.Name.StartsWith(q,comparison) || x.Space.BldgName.IndexOf(q,comparison) >= 0 // case-insensitive .Contains
+                    || x.Space.RoomNumber.StartsWith(q, comparison)))
+                .Include(x => x.Space)
+                .AsNoTracking().ToListAsync();
+
+            return Json(equipment);
+        }
+
         public async Task<IActionResult> GetWorkstationsInSpace(int spaceId)
         {
             var workstations = await _context.Workstations

--- a/Keas.Mvc/Controllers/Api/WorkstationsController.cs
+++ b/Keas.Mvc/Controllers/Api/WorkstationsController.cs
@@ -44,17 +44,6 @@ namespace Keas.Mvc.Controllers.Api
             return Json(workstations);
         }
 
-        public async Task<IActionResult> GetWorkstationsAssigned(int personId)
-        {
-            var workstations = await _context.Workstations
-                .Where(x => x.Assignment.PersonId == personId && x.Team.Name == Team && x.Active)
-                .Include(x => x.Assignment)
-                .ThenInclude(x => x.Person.User)
-                .AsNoTracking()
-                .ToListAsync();
-            return Json(workstations);
-        }
-
         public async Task<IActionResult> CommonAttributeKeys()
         {
             var keys = await _context.WorkstationAttributes

--- a/Keas.Mvc/Controllers/Api/WorkstationsController.cs
+++ b/Keas.Mvc/Controllers/Api/WorkstationsController.cs
@@ -177,9 +177,10 @@ namespace Keas.Mvc.Controllers.Api
                     
                 w.Name = workstation.Name;
                 w.Tags = workstation.Tags;
-
-                //eq.Attributes.Clear();
-                //equipment.Attributes.ForEach(x => eq.AddAttribute(x.Key, x.Value));
+                if(w.SpaceId != workstation.Space.Id)
+                {
+                    w.Space = await _context.Spaces.SingleAsync(x => x.Id == workstation.Space.Id);
+                }
 
                 await _context.SaveChangesAsync();
                 return Json(w);


### PR DESCRIPTION
counts now update better on spaces and peoples tab. 

especially on spaces tab, where you can edit an asset and reassign it to another space. it will now properly reflect that change, i.e. removing from state and updating counts for both the old and new space. 

still need to implement this for keys, but i figured it'd be cleaner just to wait for the changes on that 