### PR TITLE
special route for admin pages

### DIFF
--- a/Keas.Mvc/Startup.cs
+++ b/Keas.Mvc/Startup.cs
@@ -167,12 +167,20 @@ namespace Keas.Mvc
                     defaults: new { controller = "people", action = "Index" },
                     constraints: new { controller = "(keys|equipment|access|spaces|people|person|workstations|tags)" }
                 );
+
                 routes.MapRoute(
                     name: "Assets",
                     template: "{teamName}/{asset}/{*type}",
                     defaults: new { controller = "Asset", action = "Index" },
                     constraints: new { asset = "(keys|equipment|access|spaces|people|person|workstations)" }
                 );
+
+                routes.MapRoute(
+                    name: "AdminRoutes",
+                    template: "admin/{action=Index}/{id?}",
+                    defaults: new { controller = "Admin" }
+                );
+
                 routes.MapRoute(
                     name: "TeamRoutes",
                     template: "{teamName}/{controller=Home}/{action=Index}/{id?}");

--- a/Keas.Mvc/Views/Home/Index.cshtml
+++ b/Keas.Mvc/Views/Home/Index.cshtml
@@ -42,7 +42,7 @@
 
                         <ul>                           
                             <li>
-                                <a href="/Admin/Index">System Administration</a>
+                                <a asp-controller="Admin" asp-action="Index" >System Administration</a>
                             </li>
                         </ul></div>
                    

--- a/Keas.Mvc/Views/Team/Create.cshtml
+++ b/Keas.Mvc/Views/Team/Create.cshtml
@@ -6,7 +6,7 @@
     <div class="card-head">
         <div class="row justify-content-between">
             <h2>Create Team</h2>
-            <a class="btn btn-link" asp-action="Index"><i class="fas fa-arrow-left fa-xs" /></i> Back to List</a>
+            <a class="btn btn-link" asp-controller="Admin" asp-action="Index"><i class="fas fa-arrow-left fa-xs" /></i> Back to List</a>
         </div>
     </div>
     <div class="card-content">

--- a/Keas.Mvc/Views/Team/Edit.cshtml
+++ b/Keas.Mvc/Views/Team/Edit.cshtml
@@ -8,7 +8,7 @@
   <div class="card-head">
     <div class="row justify-content-between">
         <h2>Edit Team</h2>
-        <a class="btn btn-link" asp-action="Index"><i class="fas fa-arrow-left fa-xs"/></i> Back to List</a>
+        <a class="btn btn-link" asp-action="Index" asp-controller="Admin"><i class="fas fa-arrow-left fa-xs"/></i> Back to List</a>
     </div>
   </div>
   <div class="card-content">


### PR DESCRIPTION
admin was being interpreted as a regular team name, so we can either create a new route just for admin stuff, which i did, or we can update the "TeamRoutes" route and say that there are some "reserved" team names, like Admin.  