### PR TITLE
People are more than users

### DIFF
--- a/Keas.Core/Domain/AssetBase.cs
+++ b/Keas.Core/Domain/AssetBase.cs
@@ -29,7 +29,7 @@ namespace Keas.Core.Domain
 
         public string GetDescription(string asset, string title, Person person, string action)
         {
-            return asset + "(" + title + ") " + action + " by " + person.Name;
+            return asset + "(" + title + ") " + action + " by " + person.Name + " (" + person.UserId + ")";
         }
 
         public virtual string Title => Name;

--- a/Keas.Core/Domain/AssetBase.cs
+++ b/Keas.Core/Domain/AssetBase.cs
@@ -27,9 +27,9 @@ namespace Keas.Core.Domain
 
         public bool Active { get; set; }
 
-        public string GetDescription(string asset, string title, User user, string action)
+        public string GetDescription(string asset, string title, Person person, string action)
         {
-            return asset + "(" + title + ") " + action + " by " + user.Name;
+            return asset + "(" + title + ") " + action + " by " + person.Name;
         }
 
         public virtual string Title => Name;

--- a/Keas.Core/Domain/AssignmentBase.cs
+++ b/Keas.Core/Domain/AssignmentBase.cs
@@ -30,9 +30,9 @@ namespace Keas.Core.Domain
         public DateTime? ConfirmedAt { get; set; }
         public DateTime? NextNotificationDate { get; set; }
 
-        public string GetDescription(string asset, string title, Person person, string action, string assignee)
+        public string GetDescription(string asset, string title, Person actor, string action)
         {            
-            return asset + "(" + title + ") " + action + " to " + assignee + " by " + person.Name;
+            return asset + "(" + title + ") " + action + " to " +  Person.Name + " (" + Person.UserId + ") " + " by " + actor.Name + " (" + actor.UserId + ")";
         }
 
     }

--- a/Keas.Core/Domain/AssignmentBase.cs
+++ b/Keas.Core/Domain/AssignmentBase.cs
@@ -30,9 +30,9 @@ namespace Keas.Core.Domain
         public DateTime? ConfirmedAt { get; set; }
         public DateTime? NextNotificationDate { get; set; }
 
-        public string GetDescription(string asset, string title, User user, string action, string assignee)
+        public string GetDescription(string asset, string title, Person person, string action, string assignee)
         {            
-            return asset + "(" + title + ") " + action + " to " + assignee + " by " + user.Name;
+            return asset + "(" + title + ") " + action + " to " + assignee + " by " + person.Name;
         }
 
     }

--- a/Keas.Mvc/Services/HistoryService.cs
+++ b/Keas.Mvc/Services/HistoryService.cs
@@ -205,7 +205,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assigned", keySerial.KeySerialAssignment.Person.Name),
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assigned"),
                 ActorId = person.UserId,
                 AssetType = "KeySerial",
                 ActionType = "Assigned",
@@ -222,7 +222,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assigned", accessAssignment.Person.Name) ,
+                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assigned") ,
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Assigned",
@@ -239,7 +239,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assigned", equipment.Assignment.Person.Name) ,
+                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assigned") ,
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Assigned",
@@ -256,7 +256,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial), keySerial.Key.Title, person, "Unassigned", keySerial.KeySerialAssignment.Person.Name),
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial), keySerial.Key.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "KeySerial",
                 ActionType = "Unassigned",
@@ -273,7 +273,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Unassigned", accessAssignment.Person.Name),
+                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Unassigned",
@@ -290,7 +290,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Unassigned", equipment.Assignment.Person.Name),
+                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Unassigned",
@@ -407,7 +407,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation.Assignment), workstation.Title, person, "Assigned", workstation.Assignment.Person.Name),
+                Description = workstation.Assignment.GetDescription(nameof(workstation.Assignment), workstation.Title, person, "Assigned"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Assigned",
@@ -424,7 +424,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Unassigned", workstation.Assignment.Person.Name),
+                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Unassigned",
@@ -519,7 +519,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assignment Updated", keySerial.KeySerialAssignment.Person.Name),
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "AssignmentUpdated",
@@ -535,7 +535,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assignment Updated", accessAssignment.Person.Name),
+                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "AssignmentUpdated",
@@ -551,7 +551,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assignment Updated", equipment.Assignment.Person.Name),
+                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "AssignmentUpdated",
@@ -567,7 +567,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Assignment Updated", workstation.Assignment.Person.Name),
+                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "AssignmentUpdated",

--- a/Keas.Mvc/Services/HistoryService.cs
+++ b/Keas.Mvc/Services/HistoryService.cs
@@ -62,7 +62,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, person, "Created"),
+                Description = key.GetDescription(nameof(Key), key.Title, person, "Created"),
                 ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Created",
@@ -78,7 +78,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, person, "Created"),
+                Description = access.GetDescription(nameof(Access), access.Title, person, "Created"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Created",
@@ -94,7 +94,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Created"),
+                Description = equipment.GetDescription(nameof(Equipment), equipment.Title, person, "Created"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Created",
@@ -110,7 +110,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, person, "Updated"),
+                Description = key.GetDescription(nameof(Key), key.Title, person, "Updated"),
                 ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Updated",
@@ -126,7 +126,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, person, "Updated"),
+                Description = access.GetDescription(nameof(Access), access.Title, person, "Updated"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Updated",
@@ -142,7 +142,7 @@ namespace Keas.Mvc.Services
            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Updated"),
+                Description = equipment.GetDescription(nameof(Equipment), equipment.Title, person, "Updated"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Updated",
@@ -157,7 +157,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, person, "Inactivated"),
+                Description = key.GetDescription(nameof(Key), key.Title, person, "Inactivated"),
                 ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Inactivated",
@@ -173,7 +173,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, person, "Inactivated"),
+                Description = access.GetDescription(nameof(Access), access.Title, person, "Inactivated"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Inactivated",
@@ -189,7 +189,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Inactivated"),
+                Description = equipment.GetDescription(nameof(Equipment), equipment.Title, person, "Inactivated"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Inactivated",
@@ -205,7 +205,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assigned"),
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(Key), keySerial.Key.Title, person, "Assigned"),
                 ActorId = person.UserId,
                 AssetType = "KeySerial",
                 ActionType = "Assigned",
@@ -222,7 +222,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assigned") ,
+                Description = accessAssignment.GetDescription(nameof(Access), accessAssignment.Access.Title, person, "Assigned") ,
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Assigned",
@@ -239,7 +239,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assigned") ,
+                Description = equipment.Assignment.GetDescription(nameof(Equipment), equipment.Title, person, "Assigned") ,
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Assigned",
@@ -256,7 +256,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial), keySerial.Key.Title, person, "Unassigned"),
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(KeySerial), keySerial.Key.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "KeySerial",
                 ActionType = "Unassigned",
@@ -273,7 +273,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Unassigned"),
+                Description = accessAssignment.GetDescription(nameof(Access), accessAssignment.Access.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Unassigned",
@@ -290,7 +290,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Unassigned"),
+                Description = equipment.Assignment.GetDescription(nameof(Equipment), equipment.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Unassigned",
@@ -307,7 +307,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.Key.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Accepted"),
+                Description = keySerial.Key.GetDescription(nameof(Key), keySerial.Key.Title, person, "Accepted"),
                 ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Accepted",
@@ -325,7 +325,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, person, "Accepted") ,
+                Description = access.GetDescription(nameof(Access), access.Title, person, "Accepted") ,
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Accepted",
@@ -342,7 +342,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Accepted"),
+                Description = equipment.GetDescription(nameof(Equipment), equipment.Title, person, "Accepted"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Accepted",
@@ -359,7 +359,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Created"),
+                Description = workstation.GetDescription(nameof(Workstation), workstation.Title, person, "Created"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Created",
@@ -375,7 +375,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Updated"),
+                Description = workstation.GetDescription(nameof(Workstation), workstation.Title, person, "Updated"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Updated",
@@ -391,7 +391,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Inactivated"),
+                Description = workstation.GetDescription(nameof(Workstation), workstation.Title, person, "Inactivated"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Inactivated",
@@ -407,7 +407,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation.Assignment), workstation.Title, person, "Assigned"),
+                Description = workstation.Assignment.GetDescription(nameof(Workstation), workstation.Title, person, "Assigned"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Assigned",
@@ -424,7 +424,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Unassigned"),
+                Description = workstation.Assignment.GetDescription(nameof(Workstation), workstation.Title, person, "Unassigned"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Unassigned",
@@ -441,7 +441,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Accepted"),
+                Description = workstation.GetDescription(nameof(Workstation), workstation.Title, person, "Accepted"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Accepted",
@@ -458,7 +458,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, person, "Deleted"),
+                Description = key.GetDescription(nameof(Key), key.Title, person, "Deleted"),
                 ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Deleted",
@@ -473,7 +473,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, person, "Deleted"),
+                Description = access.GetDescription(nameof(Access), access.Title, person, "Deleted"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Deleted",
@@ -488,7 +488,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Deleted"),
+                Description = equipment.GetDescription(nameof(Equipment), equipment.Title, person, "Deleted"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Deleted",
@@ -503,7 +503,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Deleted"),
+                Description = workstation.GetDescription(nameof(Workstation), workstation.Title, person, "Deleted"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Deleted",
@@ -516,7 +516,7 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeySerialAssignmentUpdated(KeySerial keySerial)
         {
-            var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
+            var person = await _securityService.GetPerson(Key.Team.Slug);
             var historyEntry = new History
             {
                 Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assignment Updated"),
@@ -535,7 +535,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assignment Updated"),
+                Description = accessAssignment.GetDescription(nameof(Access), accessAssignment.Access.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "AssignmentUpdated",
@@ -551,7 +551,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assignment Updated"),
+                Description = equipment.Assignment.GetDescription(nameof(Equipment), equipment.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "AssignmentUpdated",
@@ -567,7 +567,7 @@ namespace Keas.Mvc.Services
             var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Assignment Updated"),
+                Description = workstation.Assignment.GetDescription(nameof(Workstation), workstation.Title, person, "Assignment Updated"),
                 ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "AssignmentUpdated",

--- a/Keas.Mvc/Services/HistoryService.cs
+++ b/Keas.Mvc/Services/HistoryService.cs
@@ -58,12 +58,12 @@ namespace Keas.Mvc.Services
         }
 
         public async Task<History> KeyCreated(Key key)
-        {
-            var user = await _securityService.GetUser();
+        {            
+            var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, user, "Created"),
-                ActorId = user.Id,
+                Description = key.GetDescription(nameof(key), key.Title, person, "Created"),
+                ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Created",
                 Key = key
@@ -75,11 +75,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> AccessCreated(Access access)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, user, "Created"),
-                ActorId = user.Id,
+                Description = access.GetDescription(nameof(access), access.Title, person, "Created"),
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Created",
                 Access = access
@@ -91,11 +91,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> EquipmentCreated(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, user, "Created"),
-                ActorId = user.Id,
+                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Created"),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Created",
                 Equipment = equipment,
@@ -107,11 +107,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeyUpdated(Key key)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, user, "Updated"),
-                ActorId = user.Id,
+                Description = key.GetDescription(nameof(key), key.Title, person, "Updated"),
+                ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Updated",
                 Key = key
@@ -123,11 +123,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> AccessUpdated(Access access)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, user, "Updated"),
-                ActorId = user.Id,
+                Description = access.GetDescription(nameof(access), access.Title, person, "Updated"),
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Updated",
                 Access = access,
@@ -139,11 +139,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> EquipmentUpdated(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+           var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, user, "Updated"),
-                ActorId = user.Id,
+                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Updated"),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Updated",
                 Equipment = equipment,
@@ -154,11 +154,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> KeyInactivated(Key key)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, user, "Inactivated"),
-                ActorId = user.Id,
+                Description = key.GetDescription(nameof(key), key.Title, person, "Inactivated"),
+                ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Inactivated",
                 Key = key
@@ -170,11 +170,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> AccessInactivated(Access access)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, user, "Inactivated"),
-                ActorId = user.Id,
+                Description = access.GetDescription(nameof(access), access.Title, person, "Inactivated"),
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Inactivated",
                 Access = access
@@ -186,11 +186,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> EquipmentInactivated(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, user, "Inactivated"),
-                ActorId = user.Id,
+                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Inactivated"),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Inactivated",
                 Equipment = equipment
@@ -202,11 +202,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeySerialAssigned(KeySerial keySerial)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, user, "Assigned", keySerial.KeySerialAssignment.Person.Name),
-                ActorId = user.Id,
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assigned", keySerial.KeySerialAssignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "KeySerial",
                 ActionType = "Assigned",
                 KeySerialId = keySerial.Id,
@@ -219,11 +219,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> AccessAssigned(AccessAssignment accessAssignment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, user, "Assigned", accessAssignment.Person.Name) ,
-                ActorId = user.Id,
+                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assigned", accessAssignment.Person.Name) ,
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Assigned",
                 AccessId = accessAssignment.AccessId,
@@ -236,11 +236,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> EquipmentAssigned(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, user, "Assigned", equipment.Assignment.Person.Name) ,
-                ActorId = user.Id,
+                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assigned", equipment.Assignment.Person.Name) ,
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Assigned",
                 Equipment = equipment,
@@ -253,10 +253,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeySerialUnassigned(KeySerial keySerial)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial), keySerial.Key.Title, user, "Unassigned", keySerial.KeySerialAssignment.Person.Name),ActorId = user.Id,
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial), keySerial.Key.Title, person, "Unassigned", keySerial.KeySerialAssignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "KeySerial",
                 ActionType = "Unassigned",
                 KeySerialId = keySerial.Id,
@@ -269,11 +270,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> AccessUnassigned(AccessAssignment accessAssignment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, user, "Unassigned", accessAssignment.Person.Name),
-                ActorId = user.Id,
+                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Unassigned", accessAssignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Unassigned",
                 AccessId = accessAssignment.AccessId,
@@ -286,11 +287,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> EquipmentUnassigned(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, user, "Unassigned", equipment.Assignment.Person.Name),
-                ActorId = user.Id,
+                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Unassigned", equipment.Assignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Unassigned",
                 Equipment = equipment,
@@ -303,11 +304,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeySerialAccepted(KeySerial keySerial)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.Key.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, user, "Accepted"),
-                ActorId = user.Id,
+                Description = keySerial.Key.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Accepted"),
+                ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Accepted",
                 Key = keySerial.Key,
@@ -321,11 +322,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> AccessAccepted(Access access)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, user, "Accepted") ,
-                ActorId = user.Id,
+                Description = access.GetDescription(nameof(access), access.Title, person, "Accepted") ,
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Accepted",
                 Access = access,
@@ -338,11 +339,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> EquipmentAccepted(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, user, "Accepted"),
-                ActorId = user.Id,
+                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Accepted"),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Accepted",
                 Equipment = equipment,
@@ -355,11 +356,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> WorkstationCreated(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, user, "Created"),
-                ActorId = user.Id,
+                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Created"),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Created",
                 Workstation = workstation,
@@ -371,11 +372,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> WorkstationUpdated(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, user, "Updated"),
-                ActorId = user.Id,
+                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Updated"),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Updated",
                 Workstation = workstation,
@@ -387,11 +388,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> WorkstationInactivated(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, user, "Inactivated"),
-                ActorId = user.Id,
+                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Inactivated"),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Inactivated",
                 Workstation = workstation
@@ -403,11 +404,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> WorkstationAssigned(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation.Assignment), workstation.Title, user, "Assigned", workstation.Assignment.Person.Name),
-                ActorId = user.Id,
+                Description = workstation.Assignment.GetDescription(nameof(workstation.Assignment), workstation.Title, person, "Assigned", workstation.Assignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Assigned",
                 Workstation = workstation,
@@ -420,11 +421,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> WorkstationUnassigned(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, user, "Unassigned", workstation.Assignment.Person.Name),
-                ActorId = user.Id,
+                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Unassigned", workstation.Assignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Unassigned",
                 Workstation = workstation,
@@ -437,11 +438,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> WorkstationAccepted(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, user, "Accepted"),
-                ActorId = user.Id,
+                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Accepted"),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Accepted",
                 Workstation = workstation,
@@ -454,11 +455,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeyDeleted(Key key)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(key.Team.Slug);
             var historyEntry = new History
             {
-                Description = key.GetDescription(nameof(key), key.Title, user, "Deleted"),
-                ActorId = user.Id,
+                Description = key.GetDescription(nameof(key), key.Title, person, "Deleted"),
+                ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "Deleted",
                 Key = key
@@ -469,11 +470,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> AccessDeleted(Access access)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(access.Team.Slug);
             var historyEntry = new History
             {
-                Description = access.GetDescription(nameof(access), access.Title, user, "Deleted"),
-                ActorId = user.Id,
+                Description = access.GetDescription(nameof(access), access.Title, person, "Deleted"),
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "Deleted",
                 Access = access
@@ -484,11 +485,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> EquipmentDeleted(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.GetDescription(nameof(equipment), equipment.Title, user, "Deleted"),
-                ActorId = user.Id,
+                Description = equipment.GetDescription(nameof(equipment), equipment.Title, person, "Deleted"),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "Deleted",
                 Equipment = equipment,
@@ -499,11 +500,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> WorkstationDeleted(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.GetDescription(nameof(workstation), workstation.Title, user, "Deleted"),
-                ActorId = user.Id,
+                Description = workstation.GetDescription(nameof(workstation), workstation.Title, person, "Deleted"),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "Deleted",
                 Workstation = workstation,
@@ -515,11 +516,11 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeySerialAssignmentUpdated(KeySerial keySerial)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
-                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, user, "Assignment Updated", keySerial.KeySerialAssignment.Person.Name),
-                ActorId = user.Id,
+                Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assignment Updated", keySerial.KeySerialAssignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Key",
                 ActionType = "AssignmentUpdated",
                 KeySerial = keySerial,
@@ -531,11 +532,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> AccessAssignmentUpdated(AccessAssignment accessAssignment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(accessAssignment.Access.Team.Slug);
             var historyEntry = new History
             {
-                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, user, "Assignment Updated", accessAssignment.Person.Name),
-                ActorId = user.Id,
+                Description = accessAssignment.GetDescription(nameof(accessAssignment.Access), accessAssignment.Access.Title, person, "Assignment Updated", accessAssignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Access",
                 ActionType = "AssignmentUpdated",
                 AccessId = accessAssignment.AccessId,
@@ -547,11 +548,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> EquipmentAssignmentUpdated(Equipment equipment)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(equipment.Team.Slug);
             var historyEntry = new History
             {
-                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, user, "Assignment Updated", equipment.Assignment.Person.Name),
-                ActorId = user.Id,
+                Description = equipment.Assignment.GetDescription(nameof(equipment), equipment.Title, person, "Assignment Updated", equipment.Assignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Equipment",
                 ActionType = "AssignmentUpdated",
                 Equipment = equipment,
@@ -563,11 +564,11 @@ namespace Keas.Mvc.Services
         }
         public async Task<History> WorkstationAssignmentUpdated(Workstation workstation)
         {
-            var user = await _securityService.GetUser();
+            var person = await _securityService.GetPerson(workstation.Team.Slug);
             var historyEntry = new History
             {
-                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, user, "Assignment Updated", workstation.Assignment.Person.Name),
-                ActorId = user.Id,
+                Description = workstation.Assignment.GetDescription(nameof(workstation), workstation.Title, person, "Assignment Updated", workstation.Assignment.Person.Name),
+                ActorId = person.UserId,
                 AssetType = "Workstation",
                 ActionType = "AssignmentUpdated",
                 Workstation = workstation,

--- a/Keas.Mvc/Services/HistoryService.cs
+++ b/Keas.Mvc/Services/HistoryService.cs
@@ -516,7 +516,7 @@ namespace Keas.Mvc.Services
 
         public async Task<History> KeySerialAssignmentUpdated(KeySerial keySerial)
         {
-            var person = await _securityService.GetPerson(Key.Team.Slug);
+            var person = await _securityService.GetPerson(keySerial.Key.Team.Slug);
             var historyEntry = new History
             {
                 Description = keySerial.KeySerialAssignment.GetDescription(nameof(keySerial.Key), keySerial.Key.Title, person, "Assignment Updated"),


### PR DESCRIPTION
Fixes #275  Use people instead of user. In our department, we have 2 Patrick Browns. So, we would need to differentiate them by name (Patrick J Brown and Patrick M Brown), then use the person, not user name to get them listed correctly in history.