### PR TITLE
Hack to Fix KeySerial

### DIFF
--- a/Keas.Mvc/Controllers/Api/KeySerialsController.cs
+++ b/Keas.Mvc/Controllers/Api/KeySerialsController.cs
@@ -207,8 +207,11 @@ namespace Keas.Mvc.Controllers.Api
                 };
 
                 // create, associate, and track
-                serial.KeySerialAssignment = assignment;
+                
                 _context.KeySerialAssignments.Add(assignment);
+                await _context.SaveChangesAsync();
+                serial.KeySerialAssignment = assignment;
+                serial.KeySerialAssignmentId = assignment.Id;
                 await _eventService.TrackAssignKeySerial(serial);
             }
 


### PR DESCRIPTION
KeySerialAssignmentId in keySerial was null.
So Save it, and assign the id as well
Closes #371