### PR TITLE
Lh/workstations and equip link

### DIFF
--- a/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Equipment/EquipmentContainer.tsx
@@ -452,7 +452,17 @@ export default class EquipmentContainer extends React.Component<IProps, IState> 
     };
 
     private _openDetailsModal = (equipment: IEquipment) => {
-        this.context.router.history.push(`${this._getBaseUrl()}/equipment/details/${equipment.id}`);
+        // if we are on spaces page, and this equipment is not assigned to this space
+        // this happens on the search
+        if (this.state.equipment.findIndex(x => x.id === equipment.id) === -1) {
+            this.context.router.history.push(
+                `/${this.context.team.slug}/equipment/details/${equipment.id}`
+            );
+        } else {
+            this.context.router.history.push(
+                `${this._getBaseUrl()}/equipment/details/${equipment.id}`
+            );
+        }
     };
 
     private _openEditModal = (equipment: IEquipment) => {

--- a/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/AssignWorkstation.tsx
@@ -15,6 +15,7 @@ interface IProps {
     modal: boolean;
     onAddNew: () => void;
     closeModal: () => void;
+    openDetailsModal: (workstation: IWorkstation) => void;
     openEditModal: (workstation: IWorkstation) => void;
     selectedWorkstation: IWorkstation;
     person?: IPerson;
@@ -130,6 +131,7 @@ export default class AssignWorkstation extends React.Component<IProps, IState> {
                                             onSelect={this._onSelected}
                                             onDeselect={this._onDeselected}
                                             space={this.props.space}
+                                            openDetailsModal={this.props.openDetailsModal}
                                         />
                                     </div>
                                 )}

--- a/Keas.Mvc/ClientApp/components/Workstations/SearchWorkstations.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/SearchWorkstations.tsx
@@ -8,6 +8,7 @@ interface IProps {
     selectedWorkstation?: IWorkstation;
     space: ISpace;
     onSelect: (workstation: IWorkstation) => void;
+    openDetailsModal: (workstation: IWorkstation) => void;
     onDeselect: () => void;
 }
 
@@ -58,19 +59,28 @@ export default class SearchWorkstations extends React.Component<IProps, IState> 
                         filterBy={() => true} // don't filter on top of our search
                         allowNew={false}
                         renderMenuItemChildren={(option, props, index) => (
-                            <div>
+                            <div className={!!option.assignment ? "disabled" : ""}>
                                 <div>
                                     <Highlighter key="name" search={props.text}>
                                         {option.name}
                                     </Highlighter>
                                 </div>
                                 <div>
+                                    {!!option.assignment ? "Assigned" : "Unassigned"}
+                                </div>
+                                <div>
                                     <small>
-                                        Room:{" "}
-                                        <Highlighter key="space.roomNumber" search={props.text}>
+                                        Space:
+                                        <Highlighter
+                                            key="space.roomNumber"
+                                            search={props.text}
+                                        >
                                             {option.space.roomNumber}
-                                        </Highlighter>{" "}
-                                        <Highlighter key="space.bldgName" search={props.text}>
+                                        </Highlighter>
+                                        <Highlighter
+                                            key="space.bldgName"
+                                            search={props.text}
+                                        >
                                             {option.space.bldgName}
                                         </Highlighter>
                                     </small>
@@ -87,7 +97,11 @@ export default class SearchWorkstations extends React.Component<IProps, IState> 
                         }}
                         onChange={selected => {
                             if (selected && selected.length === 1) {
-                                this._onSelected(selected[0]);
+                                if (!!selected[0] && !!selected[0].assignment) {
+                                    this.props.openDetailsModal(selected[0]);
+                                } else {
+                                    this._onSelected(selected[0]);
+                                }
                             }
                         }}
                         options={this.state.workstations}

--- a/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
+++ b/Keas.Mvc/ClientApp/components/Workstations/WorkstationContainer.tsx
@@ -125,6 +125,7 @@ export default class WorkstationContainer extends React.Component<IProps, IState
                         space={this.props.space}
                         onCreate={this._createAndMaybeAssignWorkstation}
                         openEditModal={this._openEditModal}
+                        openDetailsModal={this._openDetailsModal}
                         onAddNew={this._openCreateModal}
                     />
                     <RevokeWorkstation
@@ -326,9 +327,17 @@ export default class WorkstationContainer extends React.Component<IProps, IState
     };
 
     private _openDetailsModal = (workstation: IWorkstation) => {
-        this.context.router.history.push(
-            `${this._getBaseUrl()}/workstations/details/${workstation.id}`
-        );
+        // if we are on spaces or person page, and this workstation is not in our state
+        // this happens on the search, when selecting already assigned 
+        if (this.state.workstations.findIndex(x => x.id === workstation.id) === -1) {
+            this.context.router.history.push(
+                `/${this.context.team.slug}/spaces/details/${workstation.space.id}/workstations/details/${workstation.id}`
+            );
+        } else {
+            this.context.router.history.push(
+                `${this._getBaseUrl()}/workstations/details/${workstation.id}`
+            );
+        }
     };
 
     private _openEditModal = (workstation: IWorkstation) => {

--- a/Keas.Mvc/Controllers/Api/WorkstationsController.cs
+++ b/Keas.Mvc/Controllers/Api/WorkstationsController.cs
@@ -28,10 +28,12 @@ namespace Keas.Mvc.Controllers.Api
         {
             var comparison = StringComparison.OrdinalIgnoreCase;
             var equipment = await _context.Workstations
-                .Where(x => x.Team.Slug == Team && x.Active && x.Assignment == null &&
+                .Where(x => x.Team.Slug == Team && x.Active  &&
                 (x.Name.StartsWith(q,comparison) || x.Space.BldgName.IndexOf(q,comparison) >= 0 // case-insensitive .Contains
                     || x.Space.RoomNumber.StartsWith(q, comparison)))
                 .Include(x => x.Space)
+                .Include(x => x.Assignment)
+                .OrderBy(x => x.Assignment != null).ThenBy(x => x.Name)
                 .AsNoTracking().ToListAsync();
 
             return Json(equipment);
@@ -42,10 +44,12 @@ namespace Keas.Mvc.Controllers.Api
         {
             var comparison = StringComparison.OrdinalIgnoreCase;
             var equipment = await _context.Workstations
-                .Where(x => x.Team.Slug == Team && x.SpaceId == spaceId && x.Active && x.Assignment == null &&
+                .Where(x => x.Team.Slug == Team && x.SpaceId == spaceId && x.Active && 
                 (x.Name.StartsWith(q,comparison) || x.Space.BldgName.IndexOf(q,comparison) >= 0 // case-insensitive .Contains
                     || x.Space.RoomNumber.StartsWith(q, comparison)))
-                .Include(x => x.Space).AsNoTracking().ToListAsync();
+                .Include(x => x.Space).Include(x => x.Assignment)
+                .OrderBy(x => x.Assignment != null).ThenBy(x => x.Name)
+                .AsNoTracking().ToListAsync();
 
             return Json(equipment);
         }


### PR DESCRIPTION
solves bug where if you're on person or space details and click on an assigned equip/workstation, the link to details was wrong if the asset wasn't in the state
this includes a fallback option in case that happens

also adds workstation searching on existing similar to equip