### PR TITLE
Point to keyserial details instead of key details.

### DIFF
--- a/Keas.Mvc/Views/Report/ExpiringItems.cshtml
+++ b/Keas.Mvc/Views/Report/ExpiringItems.cshtml
@@ -104,7 +104,7 @@
                     @Html.DisplayFor(a => item.KeySerialAssignment.ExpiresAt)
                 </td>
                  <td>
-                    <a href='@string.Format("/{0}/{1}/details/{2}", TempData["TeamName"], "keys", item.KeyId)' >Details</a>
+                    <a href='@string.Format("/{0}/{1}/details/{2}/{3}/details/{4}", TempData["TeamName"], "keys", item.KeyId, "keyserials", item.KeySerialAssignment.KeySerialId)' >Details</a>
                 </td>
             </tr>
         }

--- a/Keas.Mvc/Views/Report/UnAcceptedItems.cshtml
+++ b/Keas.Mvc/Views/Report/UnAcceptedItems.cshtml
@@ -81,7 +81,7 @@
                    @Html.DisplayFor(a => item.KeySerialAssignment.RequestedAt) 
                 </td>
                  <td>
-                    <a href='@string.Format("/{0}/{1}/details/{2}", TempData["TeamName"], "keys", item.KeyId)' >Details</a>
+                    <a href='@string.Format("/{0}/{1}/details/{2}/{3}/details/{4}", TempData["TeamName"], "keys", item.Key.Id, "keyserials", item.KeySerialAssignment.KeySerialId)' >Details</a>
                 </td>
             </tr>
         }


### PR DESCRIPTION
Closes #540 
Should point to keyserial details instead of the key when dealing with assignments.